### PR TITLE
PR for setting the timeout on the credhub webserver

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -82,6 +82,9 @@ consumes:
   optional: true
 
 properties:
+  credhub.connection-timeout:
+    description: "The maximum amount of time the server will wait for the client to make their request after connecting before the connection is closed"
+    default: 5s
   credhub.port:
     description: "Listening port for the CredHub API"
     default: 8844

--- a/jobs/credhub/templates/application_server.yml.erb
+++ b/jobs/credhub/templates/application_server.yml.erb
@@ -13,6 +13,7 @@
 
   properties = {
     'server' => {
+      'connection-timeout' => p('credhub.connection-timeout'),
       'port' => p('credhub.port'),
       'ssl' => {
         'enabled' => true,


### PR DESCRIPTION
Hi Team,

We have noticed Concourse running into timeouts when connection to credhub on a slow network. Increasing the timeout fixes this issue for us. This PR adds a configurable timeout with a default value of 5s (the current-default).

Please let us know, if you any further questions.

Regards