### PR TITLE
Add support for skipping host name verification in BBR job

### DIFF
--- a/jobs/bbr-credhubdb/spec
+++ b/jobs/bbr-credhubdb/spec
@@ -39,3 +39,6 @@ properties:
     default: true
   credhub.data_storage.tls_ca:
     description: "CA trusted for making TLS connections to targeted database server"
+  credhub.data_storage.hostname_verification.enabled:
+    description: "Toggle certificate host name verification. WARNING: Only use if your database does not include a matching hostname in their server certificate!"
+    default: false

--- a/jobs/bbr-credhubdb/spec
+++ b/jobs/bbr-credhubdb/spec
@@ -40,5 +40,5 @@ properties:
   credhub.data_storage.tls_ca:
     description: "CA trusted for making TLS connections to targeted database server"
   credhub.data_storage.hostname_verification.enabled:
-    description: "Toggle certificate host name verification. WARNING: Only use if your database does not include a matching hostname in their server certificate!"
+    description: "Toggle certificate hostname verification. WARNING: Only use if your database does not include a matching hostname in their server certificate!"
     default: false

--- a/jobs/bbr-credhubdb/spec
+++ b/jobs/bbr-credhubdb/spec
@@ -40,5 +40,5 @@ properties:
   credhub.data_storage.tls_ca:
     description: "CA trusted for making TLS connections to targeted database server"
   credhub.data_storage.hostname_verification.enabled:
-    description: "Toggle certificate hostname verification. WARNING: If your database server certificate contains the correct hostname, the value true is strongly recommended, as disabling hostname verification results in lesser security!"
+    description: "Toggle certificate hostname verification. WARNING: If your database server certificate contains the correct hostname, the value 'true' is strongly recommended, as disabling hostname verification results in lesser security!"
     default: true

--- a/jobs/bbr-credhubdb/spec
+++ b/jobs/bbr-credhubdb/spec
@@ -40,5 +40,5 @@ properties:
   credhub.data_storage.tls_ca:
     description: "CA trusted for making TLS connections to targeted database server"
   credhub.data_storage.hostname_verification.enabled:
-    description: "Toggle certificate hostname verification. WARNING: Only use if your database does not include a matching hostname in their server certificate!"
-    default: false
+    description: "Toggle certificate hostname verification. WARNING: If your database server certificate contains the correct hostname, the value true is strongly recommended, as disabling hostname verification results in lesser security!"
+    default: true

--- a/jobs/bbr-credhubdb/templates/bbr.json.erb
+++ b/jobs/bbr-credhubdb/templates/bbr.json.erb
@@ -32,7 +32,7 @@
 
   if props.p("credhub.data_storage.require_tls")
     config[:tls] = {
-      skip_host_verify: props.p("credhub.data_storage.hostname_verification.enabled"),
+      skip_host_verify: !props.p("credhub.data_storage.hostname_verification.enabled"),
       cert: {
         ca: props.p("credhub.data_storage.tls_ca"),
       }

--- a/jobs/bbr-credhubdb/templates/bbr.json.erb
+++ b/jobs/bbr-credhubdb/templates/bbr.json.erb
@@ -32,7 +32,7 @@
 
   if props.p("credhub.data_storage.require_tls")
     config[:tls] = {
-      skip_ssl_validation: props.p("credhub.data_storage.hostname_verification.enabled"),
+      skip_host_verify: props.p("credhub.data_storage.hostname_verification.enabled"),
       cert: {
         ca: props.p("credhub.data_storage.tls_ca"),
       }

--- a/jobs/bbr-credhubdb/templates/bbr.json.erb
+++ b/jobs/bbr-credhubdb/templates/bbr.json.erb
@@ -32,6 +32,7 @@
 
   if props.p("credhub.data_storage.require_tls")
     config[:tls] = {
+      skip_ssl_validation: props.p("credhub.data_storage.hostname_verification.enabled"),
       cert: {
         ca: props.p("credhub.data_storage.tls_ca"),
       }

--- a/spec/bbr-credhubdb/bbr_json_spec.rb
+++ b/spec/bbr-credhubdb/bbr_json_spec.rb
@@ -20,7 +20,7 @@ describe 'bbr-credhubdb job' do
         'require_tls' => true,
         'tls_ca' => 'some-ca',
         'hostname_verification' => {
-            'enabled' => false
+            'enabled' => true
         }
       }
     end
@@ -35,7 +35,7 @@ describe 'bbr-credhubdb job' do
         'require_tls' => true,
         'tls_ca' => 'other-ca',
         'hostname_verification' => {
-            'enabled' => false
+            'enabled' => true
         }
       }
     end

--- a/spec/bbr-credhubdb/bbr_json_spec.rb
+++ b/spec/bbr-credhubdb/bbr_json_spec.rb
@@ -61,7 +61,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
-            'skip_ssl_validation' => false,
+            'skip_host_verify' => false,
             'cert' => {
               'ca' => 'some-ca'
             }
@@ -173,7 +173,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
-            'skip_ssl_validation' => false,
+            'skip_host_verify' => false,
             'cert' => {
               'ca' => 'some-ca'
             }
@@ -272,7 +272,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
-            'skip_ssl_validation' => false,
+            'skip_host_verify' => false,
             'cert' => {
               'ca' => 'some-ca'
             }

--- a/spec/bbr-credhubdb/bbr_json_spec.rb
+++ b/spec/bbr-credhubdb/bbr_json_spec.rb
@@ -18,7 +18,10 @@ describe 'bbr-credhubdb job' do
         'port' => 'some-port',
         'database' => 'some-database',
         'require_tls' => true,
-        'tls_ca' => 'some-ca'
+        'tls_ca' => 'some-ca',
+        'hostname_verification' => {
+            'enabled' => false
+        }
       }
     end
     let(:other_data_storage) do
@@ -30,7 +33,10 @@ describe 'bbr-credhubdb job' do
         'port' => 'other-port',
         'database' => 'other-database',
         'require_tls' => true,
-        'tls_ca' => 'other-ca'
+        'tls_ca' => 'other-ca',
+        'hostname_verification' => {
+            'enabled' => false
+        }
       }
     end
     let(:data_storage_without_host) { default_data_storage.tap { |d| d.delete('host') } }
@@ -55,6 +61,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
+            'skip_ssl_validation' => false,
             'cert' => {
               'ca' => 'some-ca'
             }
@@ -166,6 +173,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
+            'skip_ssl_validation' => false,
             'cert' => {
               'ca' => 'some-ca'
             }
@@ -264,6 +272,7 @@ describe 'bbr-credhubdb job' do
           'adapter' => 'some-type',
           'host' => 'some-host',
           'tls' => {
+            'skip_ssl_validation' => false,
             'cert' => {
               'ca' => 'some-ca'
             }


### PR DESCRIPTION
- Why? Some external databases such as on GCP and Azure do not
  include a matching hostname in their server certificate.
- For more information: see https://pivotal-io.atlassian.net/browse/BBR-7

[#178199284]

Signed-off-by: Neil Hickey <nhickey@vmware.com>