### PR TITLE
Switch sample manifest stemcell to bionic as xenial is already EOL

### DIFF
--- a/sample-manifests/credhub.yml
+++ b/sample-manifests/credhub.yml
@@ -24,7 +24,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:


### PR DESCRIPTION
Just a small adjustment to ensure bionic is the default stemcell used for the sample manifest. 