### PR TITLE
add the legacy option for openssl3 wil fix #65

### DIFF
--- a/jobs/credhub/templates/init_key_stores.erb
+++ b/jobs/credhub/templates/init_key_stores.erb
@@ -51,8 +51,16 @@ cat > ${PRIVATE_KEY_FILE} <<EOL
 <%= p('credhub.tls.private_key') %>
 EOL
 
+# legacy option is needed for openssl 3 + openjdk8 see https://github.com/pivotal/credhub-release/issues/65
+if openssl version | grep -q 3.0; then
+  LEGACY="-legacy"
+else
+  LEGACY=""
+fi
+
+
 if [ -s ${CERT_FILE} ]; then
-    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 -export -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
+    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 ${LEGACY} -export -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
             -password pass:k0*l*s3cur1tyr0ck$
 
     ${JAVA_HOME}/bin/keytool -importkeystore \


### PR DESCRIPTION
this wil fix #65

there is a bug in combination with openjdk8 and openssl 3
see https://bugs.openjdk.java.net/browse/JDK-8278989

openssl 3 has a legacy option see
https://stackoverflow.com/questions/69170537/is-openssl-v3-0-0-compatible-with-v1-1-1
https://github.com/openssl/openssl/issues/14034

the only thing we don't know is how long this legacy option is going to exist
so we should upgrade our codebase to jdk11 at some point
or help fix this jdk8 issue 