### PR TITLE
Precompile

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,6 @@
+bellsoft-jdk8u322+6-linux-amd64.tar.gz:
+  size: 106800593
+  sha: sha256:adc0e981e57e5e92bd7e3a61003809733cf6ca78fbd2611e345c3ab8352db643
 luna-hsm-client-7.4/luna-hsm-client-7.4.tar:
   size: 40878080
   object_id: 41340dab-409e-4ee6-7571-2f88d38d89b4

--- a/jobs/credhub/templates/init_key_stores.erb
+++ b/jobs/credhub/templates/init_key_stores.erb
@@ -51,8 +51,16 @@ cat > ${PRIVATE_KEY_FILE} <<EOL
 <%= p('credhub.tls.private_key') %>
 EOL
 
+# legacy option is needed for openssl 3 + openjdk8 see https://github.com/pivotal/credhub-release/issues/65
+if openssl version | grep -q 3.0; then
+  LEGACY="-legacy"
+else
+  LEGACY=""
+fi
+
+
 if [ -s ${CERT_FILE} ]; then
-    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 -export -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
+    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 ${LEGACY} -export -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
             -password pass:k0*l*s3cur1tyr0ck$
 
     ${JAVA_HOME}/bin/keytool -importkeystore \

--- a/packages/credhub/pre_packaging
+++ b/packages/credhub/pre_packaging
@@ -1,7 +1,25 @@
-set -e -x
+#!/usr/bin/env bash
+
+set -eux
 
 # Make sure we can see uname
 export PATH=$PATH:/bin:/usr/bin
+
+# Unpack Java - we support Linux 64bit otherwise we require JAVA_HOME to point to JDK
+if [ `uname` = "Linux" ]; then
+  mkdir java
+  cd java
+  tar zxvf ../bellsoft-jdk*.tar.gz --strip 1
+  export JAVA_HOME=${BUILD_DIR}/java
+else
+  if [ ! -d $JAVA_HOME ]; then
+    echo "JAVA_HOME properly set is required for non Linux builds."
+    exit 1
+  fi
+fi
+
+#setup Java path
+export PATH=$JAVA_HOME/bin:$PATH
 
 MODULE_GIT_DIR=$RELEASE_DIR/.git/modules/src/credhub
 
@@ -10,3 +28,8 @@ pushd ${BUILD_DIR}/credhub
   cp applications/credhub-api/build/libs/credhub.jar ${BUILD_DIR}/credhub/credhub.jar
   ./gradlew clean
 popd
+
+#clean build credhub data and build tools (java)
+# pushd ${BUILD_DIR}
+#   rm -rf java
+# popd

--- a/packages/credhub/spec
+++ b/packages/credhub/spec
@@ -4,3 +4,4 @@ dependencies:
 - openjdk_1.8.0
 files:
 - credhub/**/*
+- bellsoft-jdk*.tar.gz


### PR DESCRIPTION
when creating a  release it currently uses the locally installed jdk to go throug the pre-compile phase
by adding the jdk blobstore and use that blob to acutally compile the code.
makes this more stable and less error prone when compiling for example with newer jdks

this pr should not be accepted as is.
as the blobs don't exist yet
and this is merely put here is a discussion