### PR TITLE
fixes credhub to work with aws mysql aurora

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -75,6 +75,7 @@ provides:
   - credhub.data_storage.tls_ca
   - credhub.data_storage.type
   - credhub.data_storage.username
+  - credhub.data_storage.replication
 
 consumes:
 - name: postgres
@@ -211,6 +212,8 @@ properties:
     default: true
   credhub.data_storage.tls_ca:
     description: "CA trusted for making TLS connections to targeted database server"
+  credhub.data_storage.replication:
+    description: "Optional failover or load balancing mode like \"loadbalance\", \"replication\" or \"aurora\". Only available for database type \"mysql\"."
 
   # UAA Authentication
   credhub.authentication.uaa.enabled:

--- a/jobs/credhub/templates/application_spring.yml.erb
+++ b/jobs/credhub/templates/application_spring.yml.erb
@@ -23,12 +23,19 @@
     database = p('credhub.data_storage.database')
     username = p('credhub.data_storage.username')
     password = p('credhub.data_storage.password')
+    replication = p('credhub.data_storage.replication', nil)
+
+    if !replication.nil? && !replication.empty?
+      url = "jdbc:mariadb:#{replication}://#{host}:#{port}/#{database}?autoReconnect=true"
+    else
+      url = "jdbc:mariadb://#{host}:#{port}/#{database}?autoReconnect=true"
+    end
 
     properties['spring']['flyway']['locations'] << 'classpath:/db/migration/mysql'
     properties['spring']['datasource'] = {
       'username' => username,
       'password' => password,
-      'url' => "jdbc:mariadb://#{host}:#{port}/#{database}?autoReconnect=true",
+      'url' => url,
     }
 
     if p('credhub.data_storage.require_tls')
@@ -57,6 +64,10 @@
       if host == ''
         raise 'postgres `host` must be set'
       end
+    end
+
+    if !p('credhub.data_storage.replication', '').empty?
+      raise 'parameter `replication` is not allowed for postgres'
     end
 
     database = p('credhub.data_storage.database')


### PR DESCRIPTION
Hi,

here is a fix for credhub with AWS Aurora MySQL as dbms.

Credhub with Aurora MySQL worked in prior versions of credhub with an older mariadb driver without effort.

Now the mariadb driver (at least for versions < 3) can connect to AWS Aurora MySQL, when `aurora` is used as replication parameter in the connection url, see [here](https://mariadb.com/kb/en/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver/#failover-and-load-balancing-modes) and [here](https://mariadb.com/kb/en/failover-and-high-availability-with-mariadb-connector-j-for-2x-driver/#specifics-for-amazon-aurora).

This patch adds an optional job property `replication`. When set, the connection url will be like `jdbc:mariadb:<REPLICATION>://some-host:3306/some-database` for the storage type `mysql` and results in error for the storage type `postgres`.
