### PR TITLE
Improve pre-start script error log

### DIFF
--- a/jobs/credhub/templates/pre-start.erb
+++ b/jobs/credhub/templates/pre-start.erb
@@ -29,7 +29,7 @@ fail_unless_credhub_port_is_open() {
   set -e
 
   if [[ $exit_code -eq 0 ]]; then
-    echo 'It appears that CredHub process is already running on port: <%= port %>'
+    echo 'Cannot start CredHub because port <%= port %> is already occupied.'
     exit 1;
   fi
 }


### PR DESCRIPTION
- This error is caused by that the port CredHub is configured  to listen is already occupied; it does not necessary mean  the port is already occupied by the CredHub process.  So correcting the log to reflect that.