### PR TITLE
fix: keep using TLS 1.2

### DIFF
--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -25,6 +25,7 @@ export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.security.egd=file:/dev/ura
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.io.tmpdir=/var/vcap/data/credhub/exec-tmp"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.ephemeralDHKeySize=4096"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.namedGroups=\"secp384r1\""
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.client.protocols=TLSv1.2"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dlog4j2.formatMsgNoLookups=true"
 
 <%=


### PR DESCRIPTION
- The bumped java version (provided by Bellsoft) contains this change: "8245263	Enable TLSv1.3 by default on JDK 8u for Client roles" (https://bell-sw.com/pages/liberica-release-notes-8u352/)
- However, many of our CI jobs failed likley because the latest postgres-release (contains postgres 11) does not accept TLS 1.3.
- So this commit reverts back to using TLS 1.2 (the prior default) to fix CI.
- We will bump credhub to use TLS 1.3 in the future, when needed.

[#183799645]