### PR TITLE
fix: Use fips-compatible algorithm

### DIFF
--- a/jobs/credhub/templates/init_key_stores.erb
+++ b/jobs/credhub/templates/init_key_stores.erb
@@ -58,9 +58,17 @@ else
   LEGACY=""
 fi
 
+# Use Fips 140-2 compatible encryption algorithm
+if [ -f "/proc/sys/crypto/fips_enabled" ]; then
+  FIPS_OPTS="-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES"
+  echo "Using Fips 140-2 compatible encryption algorithm PBE-SHA1-3DES to package cert and key with pkcs12"
+else
+  FIPS_OPTS=""
+fi
+
 
 if [ -s ${CERT_FILE} ]; then
-    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 ${LEGACY} -export -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
+    RANDFILE=/etc/sv/monit/.rnd openssl pkcs12 ${LEGACY} -export ${FIPS_OPTS} -in ${CERT_FILE} -inkey ${PRIVATE_KEY_FILE} -out cert.p12 -name ${CERT_ALIAS} \
             -password pass:k0*l*s3cur1tyr0ck$
 
     ${JAVA_HOME}/bin/keytool -importkeystore \


### PR DESCRIPTION
Use Fips 140-2 compatible encryption algorithm PBE-SHA1-3DES to package cert and key with pkcs12 when FIPS is enabled

    Co-authored-by: Alicia Yingling <yalicia@vmware.com>
    Co-authored-by: Peter Chen <peterch@vmware.com>