### PR TITLE
fix: database connections

### DIFF
--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -24,8 +24,7 @@ export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dlog4j.configurationFile=/var/vc
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.security.egd=file:/dev/urandom"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.io.tmpdir=/var/vcap/data/credhub/exec-tmp"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.ephemeralDHKeySize=4096"
-export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.namedGroups=\"secp384r1\""
-export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.client.protocols=TLSv1.2"
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.namedGroups=\"secp384r1,secp256r1\""
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dlog4j2.formatMsgNoLookups=true"
 
 <%=

--- a/jobs/credhub/templates/credhub.erb
+++ b/jobs/credhub/templates/credhub.erb
@@ -25,6 +25,7 @@ export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.security.egd=file:/dev/ura
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djava.io.tmpdir=/var/vcap/data/credhub/exec-tmp"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.ephemeralDHKeySize=4096"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.namedGroups=\"secp384r1\""
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djdk.tls.client.protocols=TLSv1.2"
 export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dlog4j2.formatMsgNoLookups=true"
 
 <%=


### PR DESCRIPTION
Cherry-pick of a change that was previously reverted. The change was in support of a java 8 patch bump. We're now on Java 11 and need this change. This is expected to fix an error in four different deploy tasks in various acceptance test jobs that use Postgres:
```
Task 211465 | 14:42:51 | L starting jobs: credhub/d43321d0-b68d-4a52-8be7-cf3e9f109904 (0) (canary) (00:03:29)
                       L Error: 'credhub/d43321d0-b68d-4a52-8be7-cf3e9f109904 (0)' is not running after update. Review logs for failed jobs: credhub
```

This was associated with this error in the CredHub log:
```
2023-01-13T21:38:03.666Z [main] .... DEBUG --- HikariPool: HikariPool-1 - Cannot acquire connection from data source
org.postgresql.util.PSQLException: SSL error: Received fatal alert: handshake_failure
        at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:43) ~[postgresql-42.5.1.jar!/:42.5.1]
        at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:584) ~[postgresql-42.5.1.jar!/:42.5.1]
...
```
Tested locally in the CredHub repo like so, where the last -D option fixed the error on startup:
```
./scripts/start_server.sh -Dspring.profiles.active=dev,dev-postgres -Djdk.tls.client.protocols=TLSv1.2
```
Original commit message:

- The bumped java version (provided by Bellsoft) contains this change: "8245263	Enable TLSv1.3 by default on JDK 8u for Client roles" (https://bell-sw.com/pages/liberica-release-notes-8u352/)
- However, many of our CI jobs failed likley because the latest postgres-release (contains postgres 11) does not accept TLS 1.3.
- So this commit reverts back to using TLS 1.2 (the prior default) to fix CI.
- We will bump credhub to use TLS 1.3 in the future, when needed.

[#183799645]
[#184142402]