### PR TITLE
fix: Set mariadb jdbc driver's `socketTimeout`

### DIFF
--- a/jobs/credhub/templates/application_spring.yml.erb
+++ b/jobs/credhub/templates/application_spring.yml.erb
@@ -28,7 +28,7 @@
     properties['spring']['datasource'] = {
       'username' => username,
       'password' => password,
-      'url' => "jdbc:mariadb://#{host}:#{port}/#{database}?autoReconnect=true",
+      'url' => "jdbc:mariadb://#{host}:#{port}/#{database}?autoReconnect=true&socketTimeout=1200000",
     }
 
     if p('credhub.data_storage.require_tls')

--- a/spec/credhub/application_spring_yml_spec.rb
+++ b/spec/credhub/application_spring_yml_spec.rb
@@ -84,6 +84,7 @@ describe 'credhub job' do
           expected_connection_url =
             'jdbc:mariadb://some-host:3306/some-database' \
             '?autoReconnect=true' \
+            '&socketTimeout=1200000' \
             '&useSSL=true' \
             '&requireSSL=true' \
             '&verifyServerCertificate=true&enabledSslProtocolSuites=TLSv1,TLSv1.1,TLSv1.2' \
@@ -111,7 +112,8 @@ describe 'credhub job' do
 
           expected_connection_url =
             'jdbc:mariadb://some-host:3306/some-database' \
-            '?autoReconnect=true'
+            '?autoReconnect=true' \
+            '&socketTimeout=1200000'
 
           expect(rendered_template['spring']['datasource']['url']).to eq(expected_connection_url)
         end
@@ -127,6 +129,7 @@ describe 'credhub job' do
           expected_connection_url =
             'jdbc:mariadb://some-host:3306/some-database' \
             '?autoReconnect=true' \
+            '&socketTimeout=1200000' \
             '&useSSL=true' \
             '&requireSSL=true' \
             '&verifyServerCertificate=true&enabledSslProtocolSuites=TLSv1,TLSv1.1,TLSv1.2' \


### PR DESCRIPTION
- Some network condition can cause the jdbc connection creation process get stuck and no new connections to be added to the Hikari pool, resulting in “Unable to acquire JDBC Connection” error.
- It takes 8 hours, which is MySql db server's default socket timeout to recover from this situation.
- This change will lessen the recovery time to 20 minutes, which is still quite long.  However, it is a safe choice because we do not have data regarding the longest SQL transatcion time in our application.  If any of our SQl transation takes longer, then we can get SocketTimeoutException for the transaction.

[#183430962]