### PR TITLE
cleanup: Remove the Bosh blob for opendjk 1.8

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,6 @@ luna-hsm-client-7.4/luna-hsm-client-7.4.tar:
   size: 40878080
   object_id: 41340dab-409e-4ee6-7571-2f88d38d89b4
   sha: sha256:7df1df90738778437a545ca2b0fb1427ab302503791d329946ab36edd5f07ec4
-openjdk_1.8.0/bellsoft-jre8u382%2B6-linux-amd64.tar.gz:
-  size: 42069144
-  object_id: 1153665d-85d9-46a9-7796-f20068210d62
-  sha: sha256:eb812813d723e1ce0c433cb1c6341ebb3bdbe7c403d837b889eaeaf9f1e4a2e4
 openjdk_11.0/bellsoft-jre11.0.20%2B8-linux-amd64.tar.gz:
   size: 49312048
   object_id: 4d5e73a3-bc3c-4c82-7d40-fdd92dec74e8


### PR DESCRIPTION
- Which had been replaced by openjdk 11

[#184142402]