### PR TITLE
Client Certificate Generation Scripts for mTLS Auth with CredHub

### DIFF
--- a/scripts/mtls-auth/eku_config.cnf
+++ b/scripts/mtls-auth/eku_config.cnf
@@ -1,0 +1,3 @@
+[ v3_ext ]
+keyUsage = critical, digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage = clientAuth, serverAuth

--- a/scripts/mtls-auth/generate_credhub_ca_cert.sh
+++ b/scripts/mtls-auth/generate_credhub_ca_cert.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p ./certs
+
+openssl req -x509 -newkey rsa:4096 -keyout ./certs/credhub-clients-ca.key -out ./certs/credhub-clients-ca.cert -days 3650 -nodes -subj "/CN=CredhubClientsCA"

--- a/scripts/mtls-auth/generate_credhub_client_cert.sh
+++ b/scripts/mtls-auth/generate_credhub_client_cert.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CLIENT_NAME="test"
+# Client ID have to be UUID v4
+CLIENT_ID=$(uuid -v 4)
+
+FILE_NAME="client-${CLIENT_NAME}-${CLIENT_ID}"
+
+echo "=== ${FILE_NAME} ==="
+
+# private key
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048  -out "./certs/${FILE_NAME}.key"
+
+# CSR
+openssl req -new -key "./certs/${FILE_NAME}.key" -out "./certs/${FILE_NAME}.csr" -config eku_config.cnf -subj "/CN=${CLIENT_NAME}/OU=app:${CLIENT_ID}"
+# youc can use: -subj "/OU=app:<uuid-v4>/OU=space:<uuid-v4>/OU=organization:<uuid-v4>/CN=<client-name>"
+
+# CA Signature
+openssl x509 -req -in "./certs/${FILE_NAME}.csr" -CA "./certs/credhub-clients-ca.cert" -CAkey "./certs/credhub-clients-ca.key" -CAcreateserial -out "./certs/${FILE_NAME}.cert" -days 3650 -extensions v3_ext -extfile eku_config.cnf
+
+openssl x509 -in "./certs/${FILE_NAME}.cert" -text -noout > "./certs/${FILE_NAME}.cert.info"
+


### PR DESCRIPTION
This PR contains two scripts for generating CA and client certificates required for mutual TLS authentication with CredHub. 

The generated certificates follow the UUID v4 standard for client identification: `/OU=app:<uuid-v4>/OU=space:<uuid-v4>/OU=organization:<uuid-v4>/CN=<client-name>`
