### PR TITLE
Enable TLS 1.3

### DIFF
--- a/jobs/credhub/templates/application_server.yml.erb
+++ b/jobs/credhub/templates/application_server.yml.erb
@@ -3,7 +3,9 @@
     'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
     'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
     'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
-    'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+    'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+    'TLS_AES_128_GCM_SHA256',
+    'TLS_AES_256_GCM_SHA384'
   ]
   # CredHubDeprecatedStartingAfter(2.1.2)
   if p('credhub.java7_tls_ciphers_enabled')
@@ -17,7 +19,7 @@
       'port' => p('credhub.port'),
       'ssl' => {
         'enabled' => true,
-        'enabled_protocols' => 'TLSv1.2',
+        'enabled_protocols' => 'TLSv1.2,TLSv1.3',
         'ciphers' => ciphers.join(','),
         'key_store' => '/var/vcap/jobs/credhub/config/cacerts.jks',
         'key_password' => '${KEY_STORE_PASSWORD}',

--- a/spec/credhub/application_server_yml_spec.rb
+++ b/spec/credhub/application_server_yml_spec.rb
@@ -23,7 +23,7 @@ describe 'credhub job' do
         rendered_template = YAML.safe_load(template.render(manifest))
 
         expect(rendered_template['server']['ssl']['enabled']).to eq(true)
-        expect(rendered_template['server']['ssl']['enabled_protocols']).to eq('TLSv1.2')
+        expect(rendered_template['server']['ssl']['enabled_protocols']).to eq('TLSv1.2,TLSv1.3')
         expect(rendered_template['server']['ssl']['key_store']).to eq('/var/vcap/jobs/credhub/config/cacerts.jks')
         expect(rendered_template['server']['ssl']['key_password']).to eq('${KEY_STORE_PASSWORD}')
         expect(rendered_template['server']['ssl']['key_store_password']).to eq('${KEY_STORE_PASSWORD}')
@@ -40,6 +40,8 @@ describe 'credhub job' do
                                 TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
                                 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
                                 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                                TLS_AES_128_GCM_SHA256
+                                TLS_AES_256_GCM_SHA384
                               ])
       end
 
@@ -91,6 +93,8 @@ describe 'credhub job' do
                                 TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
                                 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
                                 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                                TLS_AES_128_GCM_SHA256
+                                TLS_AES_256_GCM_SHA384
                                 TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
                                 TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
                               ])


### PR DESCRIPTION
This enables TLS 1.3 for the CredHub inbound communication. 
Only the two  TLS 1.3 GCM ciphersuites are allowed because of FIPS compliance

Tests:: 
- Run the ruby test successfully 
- Tested the change manually successfully
- Tested the change in a SAP BTP dev landscape as dev bosh release successfully

