### PR TITLE
remove: unused `server.connection-timeout` property

### DIFF
--- a/jobs/credhub/spec
+++ b/jobs/credhub/spec
@@ -82,9 +82,6 @@ consumes:
   optional: true
 
 properties:
-  credhub.connection-timeout:
-    description: "The maximum amount of time the server will wait for the client to make their request after connecting before the connection is closed"
-    default: 5s
   credhub.port:
     description: "Listening port for the CredHub API"
     default: 8844

--- a/jobs/credhub/templates/application_server.yml.erb
+++ b/jobs/credhub/templates/application_server.yml.erb
@@ -15,7 +15,6 @@
 
   properties = {
     'server' => {
-      'connection-timeout' => p('credhub.connection-timeout'),
       'port' => p('credhub.port'),
       'ssl' => {
         'enabled' => true,


### PR DESCRIPTION
- The properyy had been removed in spring-boot 2.3, which means that the propery has been ignored by CredHub server.
- TNZ-42548